### PR TITLE
Force use of versionFolder's Name instead of FullName

### DIFF
--- a/src/generate.ps1
+++ b/src/generate.ps1
@@ -39,7 +39,7 @@ Get-ChildItem -Recurse -Include "*.css" "WebKit/Source/WebInspectorUI/UserInterf
 echo "Copying InspectorBackendCommands.js for the latest version"
 $protocolPath = 'WebKit/Source/WebInspectorUI/UserInterface/Protocol'
 $legacyPath = "$protocolPath/Legacy/iOS"
-$versionFolder = (Get-ChildItem $legacyPath | Sort-Object Name -Descending)[0]
+$versionFolder = (Get-ChildItem $legacyPath | Sort-Object Name -Descending)[0].Name
 $backendCommandsFile = "$legacyPath/$versionFolder/InspectorBackendCommands.js"
 echo "  -> Choosing file $backendCommandsFile"
 cp $backendCommandsFile $protocolPath


### PR DESCRIPTION
In Powershell 7, the default behaviour of converting a file item to string, i.e.
```powershell
$> "$(SomeFileItem)"
```
changed from `SomeFileItem.Name` to `SomeFileItem.FullName`.

This behavioural change results in an error when running `generate.ps1`:
```powershell
Copying InspectorBackendCommands.js for the latest version
  -> Choosing file WebKit/Source/WebInspectorUI/UserInterface/Protocol/Legacy/iOS/C:\Path\To\Root\ios-safari-remote-debug-kit\src\WebKit\Source\WebInspectorUI\UserInterface\Protocol\Legacy\iOS\16.0/InspectorBackendCommands.js
Copy-Item: C:\Path\To\Root\ios-safari-remote-debug-kit\src\generate.ps1:45
Line |
  45 |  cp $backendCommandsFile $protocolPath
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot find drive. A drive with the name
     | 'WebKit/Source/WebInspectorUI/UserInterface/Protocol/Legacy/iOS/C' does not exist.
```

This PR addresses it by forcing use of property `Name`.
```powershell
$versionFolder = (Get-ChildItem $legacyPath | Sort-Object Name -Descending)[0].Name
```
