### PR TITLE
Stubbing InspectorFrontendHost.engineeringSettingsAllowed

### DIFF
--- a/src/injectedCode/InspectorFrontendHostStub.js
+++ b/src/injectedCode/InspectorFrontendHostStub.js
@@ -188,6 +188,10 @@ WI.InspectorFrontendHostStub = class InspectorFrontendHostStub {
         return false;
     }
 
+    engineeringSettingsAllowed() {
+        return false;
+    }
+
     get debuggableInfo() {
         return {
             debuggableType: "web-page",


### PR DESCRIPTION
WebKit upstream introduced `InspectorFrontendHost.engineeringSettingsAllowed` in commmit https://github.com/WebKit/WebKit/commit/2326b1146886546de0d44f6aa85415b2e1257b8a, breaking the inspector.