### PR TITLE
Update start.sh

### DIFF
--- a/src/start.sh
+++ b/src/start.sh
@@ -15,7 +15,7 @@ if [ "$1" != "-noServer" ] && [ ! -d "WebKit" ]; then
   exit
 fi
 
-DEBUG_PROXY_EXE="ios-webkit-debug-proxy"
+DEBUG_PROXY_EXE="ios_webkit_debug_proxy"
 
 if [ "$1" != "-noServer" ]; then
   echo "Running ios-webkit-debug-proxy..."


### PR DESCRIPTION
According to [ios-webkit-debug-proxy](https://github.com/google/ios-webkit-debug-proxy#start-the-proxy), the command is actually `ios_webkit_debug_proxy`.  Changing this in start.sh fixed an issue I ran into where the command `ios-webkit-debug-proxy` was not found.

Note: I have NOT tested this on Windows, only an Ubuntu-based Linux distribution (Pop!_OS)