### PR TITLE
Fix for powershell 7

### DIFF
--- a/src/start.ps1
+++ b/src/start.ps1
@@ -64,7 +64,7 @@ $jobBlock = {
     if (Get-Command $pythonCmd -ErrorAction SilentlyContinue) {
         $storeAppAliasPath = [Environment]::GetFolderPath([Environment+SpecialFolder]::LocalApplicationData) + "\Microsoft\WindowsApps\"
         if ((Get-Command $pythonCmd).Source.StartsWith($storeAppAliasPath)) {
-            if ((Get-AppxPackage -Publisher "CN=4975D53F-AA7E-49A5-8B49-EA4FDC1BB66B").Count -ne 0) {
+            if ([int](powershell.exe -NoProfile -Command "(Get-AppxPackage -Publisher 'CN=4975D53F-AA7E-49A5-8B49-EA4FDC1BB66B' | Measure-Object).Count") -ne 0) {
                 $pythonInstalled = $true
             }
         } else {


### PR DESCRIPTION
Appx-Commands are not available in powershell 7, this calls powershell 5 to get the Appx-Package, and thus makes this script pwoershell 7-compatible.
With the current script, the following error is produced when launched from powershell 7:
```
Searching web server
ObjectNotFound: The 'Get-AppxPackage' command was found in the module 'Appx', but the module could not be loaded due to the following error: [Could not load file or assembly 'Microsoft.Windows.Appx.PackageManager.Commands, Version=10.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. Assembly with same name is already loaded]
For more information, run 'Import-Module Appx'.
Found http-server, using it to serve the WebInspector
```